### PR TITLE
Provide the ability to transfer the External Refund contract

### DIFF
--- a/contracts/ExternalRefund.sol
+++ b/contracts/ExternalRefund.sol
@@ -1,13 +1,14 @@
 pragma solidity ^0.5.0;
 
 import 'hardlydifficult-ethereum-contracts/contracts/interfaces/IPublicLock.sol';
+import "@openzeppelin/contracts/ownership/Ownable.sol";
 import '@openzeppelin/contracts/access/roles/WhitelistedRole.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 
 
 /**
  */
-contract ExternalRefund is WhitelistedRole
+contract ExternalRefund is Ownable, WhitelistedRole
 {
   IPublicLock public lock;
   mapping(address => bool) public refundee;

--- a/contracts/ExternalRefund.sol
+++ b/contracts/ExternalRefund.sol
@@ -1,7 +1,7 @@
 pragma solidity ^0.5.0;
 
 import 'hardlydifficult-ethereum-contracts/contracts/interfaces/IPublicLock.sol';
-import "@openzeppelin/contracts/ownership/Ownable.sol";
+import '@openzeppelin/contracts/ownership/Ownable.sol';
 import '@openzeppelin/contracts/access/roles/WhitelistedRole.sol';
 import '@openzeppelin/contracts/token/ERC20/IERC20.sol';
 


### PR DESCRIPTION
With the request to have a multisig own the contract, we must ensure that the contract can be transferred after deployment.

After deploying the contract, the contract owner will need to ensure that the have made the new owner a WhitelistAdmin prior to the handover